### PR TITLE
Replace `Buffer.from` with `new Buffer`

### DIFF
--- a/src/profile_service/index.js
+++ b/src/profile_service/index.js
@@ -110,7 +110,7 @@ function decipherProfile(cipherText, key, iv, callback) {
 }
 
 function unwrapKey(wrappedKey, pem) {
-  let wrappedKeyBuffer = Buffer.from(wrappedKey, 'base64');
+  let wrappedKeyBuffer = new Buffer(wrappedKey, 'base64');
   let privateKey = ursa.createPrivateKey(pem);
   let unwrappedKey = privateKey.decrypt(wrappedKeyBuffer, 'base64', 'base64', ursa.RSA_PKCS1_PADDING);
 


### PR DESCRIPTION
`src/profile_service/index.js`

`Buffer.from` is not avaliable in Node < 5.10
https://nodejs.org/dist/latest-v7.x/docs/api/buffer.html#buffer_class_method_buffer_from_buffer

Changing it to `new Buffer` allows users with older node versions to use the SDK.

Fixes issue #3